### PR TITLE
tagging bug fix, minor comment changes

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -95,12 +95,14 @@ SQL
 
       post.custom_fields["is_accepted_answer"] = "true"
       topic.custom_fields["accepted_answer_post_id"] = post.id
-      # makes plugin recognize tags
+      # heartsupport tags
       needs_support_tag = Tag.find_or_create_by(name: 'Needs Support')
       supported_tag = Tag.find_or_create_by(name: 'Supported')
-      # because user accepted support, deletes 'needs support' tag and adds 'supported' tag.
+      # accepting a post as supportive deletes needs support tag and adds supported tag
       topic.tags.delete needs_support_tag
-      topic.tags << supported_tag
+      if (!topic.tags.include?(supported_tag))
+        topic.tags << supported_tag
+      end
 
       if defined?(UserAction::SOLVED)
         UserAction.log_action!(
@@ -186,12 +188,11 @@ SQL
         ).destroy_all
       end
 
-      # makes plugin recognize tags
+      # heartsupport tags
       needs_support_tag = Tag.find_or_create_by(name: 'Needs Support')
       supported_tag = Tag.find_or_create_by(name: 'Supported')
-      # because user unaccepted support, deletes 'supported' tag and adds 'needs support' tag.
+      # since the user unaccepted support, remove the supported tag.
       topic.tags.delete supported_tag
-      # topic.tags << needs_support_tag
 
       # yank notification
       notification = Notification.find_by(


### PR DESCRIPTION
Fixed tagging bug that was causing 500 error upon selection of a different "supported" comment. 